### PR TITLE
slight problem with delay_out

### DIFF
--- a/process_input.py
+++ b/process_input.py
@@ -16,13 +16,12 @@ for key in info:
 
 assert name is not None, "We need at least one in"
 
-
 if delay_out:
     with open(input_file_name, "rb") as input_file:
         with open(f"{name}.raw", "wb") as output_file:
-            for i in range(delay_out):
-                output_file.write(0)
             output_file.write(input_file.read())
+            for i in range(delay_out):
+                output_file.write(b'\0')
 else:
     shutil.copy(input_file_name, f"{name}.raw")
 


### PR DESCRIPTION
Hi guys, to get my unit tests running with your testbench generator, I had to make this small change to process_inputs.py ... basically adding null bytes to the *end* of the input file, not the beginning ... it looks like maybe there was a slight error in the processing of the delay_out parameter, which I think does not get used in standard testing, but which I need for e.g. linebuffer unit tests...please verify that this will not break anything for you, and approve the pull...thanks!

PS FYI here's a pointer to my travis test which uses this branch https://travis-ci.org/StanfordAHA/CGRAGenerator